### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -14,6 +14,8 @@ jobs:
     services:
       postgres:
         image: postgres:11
+        env:
+          POSTGRES_PASSWORD: postgres
         options: >-
           --health-cmd pg_isready
           --health-interval 10s

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup environment
-        run: apk --update add gcc libffi-dev libpq make musl-dev postgresql postgresql-dev linux-headers tzdata
+        run: apk --update add gcc libffi-dev libpq make musl-dev postgresql postgresql-dev linux-headers tzdata --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
       - name: Install testing dependencies
         run: pip3 install -r requires/testing.txt

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -24,6 +24,7 @@ jobs:
         ports:
           - 5432
     strategy:
+      fail-fast: false
       matrix:
         python: [3.7, 3.8, 3.9]
         postgres: [11, 12, 13]

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -38,11 +38,11 @@ jobs:
       - name: Setup environment
         run: apk --update add gcc libffi-dev libpq make musl-dev postgresql postgresql-dev linux-headers tzdata
 
-      - name: Setup test/fixture data
-        run: ci/test-setup.sh
-
       - name: Install testing dependencies
         run: pip3 install -r requires/testing.txt
+
+      - name: Setup test/fixture data
+        run: ci/test-setup.sh
 
       - name: Install library dependencies
         run: python setup.py develop

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v1
 
       - name: Setup environment
-        run: apk --update add gcc libffi-dev libpq make musl-dev postgresql postgresql-dev linux-headers tzdata --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
+        run: apk --update add gcc bash libffi-dev libpq make musl-dev postgresql postgresql-dev linux-headers tzdata --repository=http://dl-cdn.alpinelinux.org/alpine/edge/main
 
       - name: Install testing dependencies
         run: pip3 install -r requires/testing.txt
@@ -54,7 +54,6 @@ jobs:
         run: nosetests -x
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v1.0.2
+        uses: codecov/codecov-action@v1
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
           file: build/coverage.xml

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres:11
+        image: postgres:${{ matrix.postgres }}
         env:
           POSTGRES_PASSWORD: postgres
         options: >-
@@ -25,7 +25,8 @@ jobs:
           - 5432
     strategy:
       matrix:
-        python: [3.7, 3.8]
+        python: [3.7, 3.8, 3.9]
+        postgres: [11, 12, 13]
     container:
       image: python:${{ matrix.python }}-alpine
       env:

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -1,5 +1,6 @@
 name: Testing
 on:
+  pull_request:
   push:
     branches: ["*"]
     paths-ignore:

--- a/ci/test-setup.sh
+++ b/ci/test-setup.sh
@@ -2,6 +2,7 @@
 mkdir -p build/data
 cp /usr/share/zoneinfo/America/New_York /etc/localtime
 echo "America/New_York" > /etc/timezone
+export PGPASSWORD=postgres
 if test -f "build/data/dump.not-compressed"; then
   echo "Test data already exists"
 else
@@ -16,6 +17,7 @@ else
 fi
 cat > build/test-environment<<EOF
 export PGDATABASE=postgres
+export PGPASSWORD=postgres
 export PGUSER=postgres
-export POSTGRES_URI=postgresql://postgres@postgres:5432/postgres
+export POSTGRES_URI=postgresql://postgres:postgres@postgres:5432/postgres
 EOF

--- a/ci/test-setup.sh
+++ b/ci/test-setup.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env sh
+set -e
 mkdir -p build/data
 cp /usr/share/zoneinfo/America/New_York /etc/localtime
 echo "America/New_York" > /etc/timezone

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: SQL
     Topic :: Database


### PR DESCRIPTION
Newer versions of `Postgres` Docker images require `POSTGRES_PASSWORD` for security reasons: https://stackoverflow.com/questions/60618118/docker-postgres-image-failed-to-initialize-db-service-is-unhealthy.

I also added tests for Python 3.9, Postgres 12 & 13.